### PR TITLE
Update to sbt 0.12.1

### DIFF
--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.11.2
+sbt.version=0.12.1

--- a/src/main/scala/org/example/SimpleScalaBenchmark.scala
+++ b/src/main/scala/org/example/SimpleScalaBenchmark.scala
@@ -7,7 +7,7 @@ trait SimpleScalaBenchmark extends SimpleBenchmark {
   // helper method to keep the actual benchmarking methods a bit cleaner
   // your code snippet should always return a value that cannot be "optimized away"
   def repeat[@specialized A](reps: Int)(snippet: => A) = {
-    val zero = 0.asInstanceOf[A] // looks wierd but does what it should: init w/ default value in a fully generic way
+    val zero = 0.asInstanceOf[A] // looks weird but does what it should: init w/ default value in a fully generic way
     var i = 0
     var result = zero
     while (i < reps) {


### PR DESCRIPTION
javaOptions is now a TaskKey so setting the caliper classpath is much easier.
